### PR TITLE
fix github alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,20 @@
-<p align="center">
-  <h1 align="center">Metodologie di Programmazione [A.A. 2022-2023]</h1>
-</p>
 <div align="center">
+
+# Metodologie di Programmazione [A.A. 2022-2023]
 
 ## Introduzione
 Lo scopo di questo repository GitHub è proporre e discutere insieme possibili soluzioni e/o approcci risolutivi alle tracce d'esame passate fornite dai professori di Metodologie di Programmazione del canale A/L negli anni accademici dal 2020-2021 al 2022-2023, per cui non sono attualmente disponibili delle soluzioni ufficiali. In questo repository potrai dunque trovare (e possibilmente confermare) soluzioni proposte da altri studenti o anche condividere e ricevere un feedback in merito alle tue!
 
 ## Esami
+</div>
+
 > [!NOTE]
 > Per ogni esame contribuisci con una tua eventuale proposta di soluzione o consulta e dai un feedback in merito a quelle condivise da altri studenti e studentesse nell'apposita e relativa pagina di discussione
 
+<div align="center">
+
 | Data appello | Discussione |
-|------|-------|
+|:---:|:---:|
 | 07/09/2023 | [Discuti](https://github.com/sapienzastudentsnetwork/mdp2223/discussions/9) |
 | 13/07/2023 | [Discuti](https://github.com/sapienzastudentsnetwork/mdp2223/discussions/8) |
 | 13/06/2023 | [Discuti](https://github.com/sapienzastudentsnetwork/mdp2223/discussions/7) |
@@ -21,3 +24,5 @@ Lo scopo di questo repository GitHub è proporre e discutere insieme possibili s
 | 02/07/2021 | [Discuti](https://github.com/sapienzastudentsnetwork/mdp2223/discussions/3) |
 | 16/06/2021 | [Discuti](https://github.com/sapienzastudentsnetwork/mdp2223/discussions/2) |
 | 19/05/2021 | [Discuti](https://github.com/sapienzastudentsnetwork/mdp2223/discussions/1) |
+
+</div>


### PR DESCRIPTION
Gli [alert](https://github.com/orgs/community/discussions/16925) di github non vengono renderizzati correttamente se inseriti all'interno di tag HTML.